### PR TITLE
use clorox instead of chalk?

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const chalk = require('chalk');
+const clorox = require('clorox');
 
 const errorLabel = 'Syntax error:';
 const isLikelyASyntaxError = str => str.includes(errorLabel);
@@ -55,7 +55,7 @@ function formatMessage(message, isError) {
     lines[1] = lines[1].replace(exportRegex, "$1 '$4' does not contain an export named '$3'.");
   }
 
-  lines[0] = chalk.inverse(lines[0]);
+  lines[0] = clorox.inverse(lines[0]);
 
   // Reassemble & Strip internal tracing, except `webpack:` -- (create-react-app/pull/1050)
   return lines.join('\n').replace(stackRegex, '').trim();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "output"
   ],
   "dependencies": {
-    "chalk": "^2.0.1"
+    "clorox": "^1.0.3"
   }
 }


### PR DESCRIPTION
Hey — wonder what you'd think about using [clorox](https://github.com/jorgebucaran/clorox) here instead of chalk? It does exactly the same thing (at least as far as this package is concerned) but much more simply:

* http://npm.anvaka.com/#/view/2d/clorox
* http://npm.anvaka.com/#/view/2d/chalk
* https://bundlephobia.com/result?p=clorox@1.0.3
* https://bundlephobia.com/result?p=chalk@2.3.2

No problem if you'd rather keep it aligned with CRA.

(For context, I'm trying to reduce the install time/footprint of Sapper)