### PR TITLE
fix "this" undefined error in kleur

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * see: https://github.com/facebookincubator/create-react-app/tree/master/packages/react-dev-utils
  */
 
-const { inverse } = require('kleur');
+const colors = require('kleur');
 
 const errorLabel = 'Syntax error:';
 const isLikelyASyntaxError = str => str.includes(errorLabel);
@@ -53,7 +53,7 @@ function formatMessage(message, isError) {
     lines[1] = lines[1].replace(exportRegex, "$1 '$4' does not contain an export named '$3'.");
   }
 
-  lines[0] = inverse(lines[0]);
+  lines[0] = colors.inverse(lines[0]);
 
   // Reassemble & Strip internal tracing, except `webpack:` -- (create-react-app/pull/1050)
   return lines.join('\n').replace(stackRegex, '').trim();


### PR DESCRIPTION
When I try to build the [sapper-template](https://github.com/sveltejs/sapper-template) project using `npm run build`, I get this error:

<details>
<summary>Click to see error</summary>

```
/home/nolan/workspace/sapper/dist/core.js:681                                                                                                                                                                 
                let isChain = !!this.keys;                                                                                                                                                                    
                                     ^                                                                                                                                                                        
                                                                                                                                                                                                              
TypeError: Cannot read property 'keys' of undefined                                                                                                                                                           
    at /home/nolan/workspace/sapper/dist/core.js:681:24                                                                                                                                                       
    at formatMessage (/home/nolan/workspace/sapper/dist/core.js:752:14)                                                                                                                                       
    at result.warnings.json.warnings.map.msg (/home/nolan/workspace/sapper/dist/core.js:763:38)                                                                                                               
    at Array.map (<anonymous>)                                                                                                                                                                                
    at webpackFormatMessages (/home/nolan/workspace/sapper/dist/core.js:763:27)                                                                                                                               
    at new WebpackResult (/home/nolan/workspace/sapper/dist/core.js:807:24)                                                                                                                                   
    at /home/nolan/workspace/sapper/dist/core.js:850:30                                                                                                                                                       
    at finalCallback (/home/nolan/workspace/sapper-template/node_modules/webpack/lib/Compiler.js:210:39)                                                                                                      
    at hooks.done.callAsync.err (/home/nolan/workspace/sapper-template/node_modules/webpack/lib/Compiler.js:259:14)                                                                                           
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/home/nolan/workspace/sapper-template/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:6:1)                                        
    at AsyncSeriesHook.lazyCompileHook (/home/nolan/workspace/sapper-template/node_modules/tapable/lib/Hook.js:154:20)                                                                                        
    at emitRecords.err (/home/nolan/workspace/sapper-template/node_modules/webpack/lib/Compiler.js:257:22)                                                                                                    
    at Compiler.emitRecords (/home/nolan/workspace/sapper-template/node_modules/webpack/lib/Compiler.js:371:39)                                                                                               
    at emitAssets.err (/home/nolan/workspace/sapper-template/node_modules/webpack/lib/Compiler.js:251:10)                                                                                                     
    at hooks.afterEmit.callAsync.err (/home/nolan/workspace/sapper-template/node_modules/webpack/lib/Compiler.js:357:14)                                                                                      
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/home/nolan/workspace/sapper-template/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:15:1) 
```

</details>
&nbsp;

Apparently `kleur` prefers the format `kleur.inverse()` rather than just `inverse()` and may throw an error if `this` is undefined. In particular, the error comes from [this line](https://github.com/lukeed/kleur/blob/7528bcd17017d2c30e038b6abe55f0423ed24f2b/index.js#L93).

I've confirmed that this PR fixes the issue.