### PR TITLE
Convert webpack v5 error object to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,12 @@ const stackRegex = /^\s*at\s((?!webpack:).)*:\d+:\d+[\s\)]*(\n|$)/gm;
 function formatMessage(message, isError) {
 	// Webpack v5 gives us an object, not a string, but message.details is
 	// what we are interested in here.
-	if (typeof message === "object" && typeof message.details === "string") {
-		message = message.details;
+	if (typeof message === "object") {
+		if (typeof message.details === "string") {
+			message = message.details;
+		} else if (typeof message.stack === "string") {
+			message = message.stack;
+		}
 	}
 
   let lines = message.split('\n');

--- a/index.js
+++ b/index.js
@@ -12,6 +12,12 @@ const exportRegex = /\s*(.+?)\s*(")?export '(.+?)' was not found in '(.+?)'/;
 const stackRegex = /^\s*at\s((?!webpack:).)*:\d+:\d+[\s\)]*(\n|$)/gm;
 
 function formatMessage(message, isError) {
+	// Webpack v5 gives us an object, not a string, but message.details is
+	// what we are interested in here.
+	if (typeof message === "object" && typeof message.details === "string") {
+		message = message.details;
+	}
+
   let lines = message.split('\n');
 
   if (lines.length > 2 && lines[1] === '') {


### PR DESCRIPTION
## What does it do?

The `formatMessage` function was expecting a string. Webpack v5 gives an error object and not just a string. In this case I changed `message` to `message.details` and it worked.

## How to test

```sh
git clone https://github.com/sveltejs/sapper.git
git clone -b webpack-v5-support https://github.com/youreadforme/webpack-format-messages.git

# setup webpack-format-message
cd webpack-format-messages
npm link

# setup sapper
cd ../sapper
npm install --ignore-scripts # i don't want to build puppeteer, tyvm

# build sapper with our branch
npm rm webpack-format-messages
npm link webpack-format-messages
npm link
npm run build
cd ..

# create a sapper site
npx degit "sveltejs/sapper-template#webpack" wfm-test
cd wfm-test

# upgrade all modules, including webpack, to the most recent version, even the alpha or beta
npm install -g npm-check-updates
ncu -unt
npm install
npm rm sapper
npm link sapper

# put some garbage in to crash webpack
echo 'import "safbvlajsnvasog58h"' > src/routes/yaaaah.js

# log the webpack error message without crashing
npm run dev

# clean up
cd ..
rm -rf sapper webpack-format-messages wfm-test
```

ncu ↓
<img width="341" alt="Screen Shot 2019-11-17 at 11 07 41 AM" src="https://user-images.githubusercontent.com/1634015/69011683-83a31180-092a-11ea-825c-ae048a6f803c.png">

log webpack error without crashing ↓
<img width="728" alt="Screen Shot 2019-11-17 at 11 08 04 AM" src="https://user-images.githubusercontent.com/1634015/69011687-8867c580-092a-11ea-8353-91925f84d8ba.png">
