### PR TITLE
fix: use more performant options for `stats.toJSON()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,11 @@ export function formatMessage(message) {
 }
 
 export function formatMessages(stats) {
-	const { errors, warnings } = stats.toJson({}, true);
+	const { errors, warnings } = stats.toJson({
+		all: false,
+		errors: true,
+		warnings: true
+	});
 
 	const result = {
 		errors: errors.map(formatMessage),


### PR DESCRIPTION
This is a big contributor to increased rebuild times with webpack@5 for me.